### PR TITLE
Allow closed stdin (#82)

### DIFF
--- a/src/doge/core.py
+++ b/src/doge/core.py
@@ -207,7 +207,7 @@ class Doge:
 
     def get_stdin_data(self):
         """Get words from stdin."""
-        if self.tty.in_is_tty:
+        if not self.tty.stdin_preferred:
             # No pipez found
             return False
 
@@ -312,14 +312,14 @@ class TTYHandler:
     def __init__(self):
         self.height = 25
         self.width = 80
-        self.in_is_tty = True
+        self.stdin_preferred = False
         self.out_is_tty = True
         self.pretty = True
 
     def setup(self):
         """Calculate terminal properties."""
         self.width, self.height = shutil.get_terminal_size()
-        self.in_is_tty = sys.stdin.isatty()
+        self.stdin_preferred = (not sys.stdin.isatty()) if sys.stdin else False
         self.out_is_tty = sys.stdout.isatty()
 
         self.pretty = self.out_is_tty

--- a/src/doge/core.py
+++ b/src/doge/core.py
@@ -207,7 +207,7 @@ class Doge:
 
     def get_stdin_data(self):
         """Get words from stdin."""
-        if not self.tty.stdin_preferred:
+        if not self.tty.in_is_pipe:
             # No pipez found
             return False
 
@@ -312,14 +312,14 @@ class TTYHandler:
     def __init__(self):
         self.height = 25
         self.width = 80
-        self.stdin_preferred = False
+        self.in_is_pipe = False
         self.out_is_tty = True
         self.pretty = True
 
     def setup(self):
         """Calculate terminal properties."""
         self.width, self.height = shutil.get_terminal_size()
-        self.stdin_preferred = (not sys.stdin.isatty()) if sys.stdin else False
+        self.in_is_pipe = (not sys.stdin.isatty()) if sys.stdin else False
         self.out_is_tty = sys.stdout.isatty()
 
         self.pretty = self.out_is_tty


### PR DESCRIPTION
Solves #82 

Allowing to handle closed stdin, which is interpreted as the standard "no pipe" word generation.
Changing `TTYHandler.in_is_tty` attribute to `TTYHandler.stdin_preferred` to better reflect usage of stdin.